### PR TITLE
Updating the CentOS installers and upgraders to check for version 6.3 and above.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ The new installers and upgrade scripts enable you to install/upgrade  ZPanel dir
 Installation is now as simple as:-
 
 ```curl -Ss
-https://raw.github.com/zpanel/installers/master/install/CentOS-6_4/10_1_1.sh | bash```
+https://raw.github.com/zpanel/installers/master/install/CentOS-6_3+/10_1_1.sh | bash```
 
 ...and to upgrade your server (for example from ZPanel 10.1.0 to 10.1.1):-
 
 ```curl -Ss
-https://raw.github.com/zpanel/installers/master/upgrade/CentOS-6_4/10_1_1.sh | bash```
+https://raw.github.com/zpanel/installers/master/upgrade/CentOS-6_3+/10_1_1.sh | bash```
 
 *The above examples demonstrate the installation of ZPanel 10.1.1 and upgrading a server running CentOS 6.4*
 
@@ -26,7 +26,7 @@ https://raw.github.com/zpanel/installers/master/upgrade/CentOS-6_4/10_1_1.sh | b
 As a relatively small team of guys and due to the time required to keep installation packages updated and tested we have officially decided to support and maintain the following operating systems/distributions.
 
 - Latest Ubuntu Server LTS release (currently 12.04 LTS)
-- Latest CentOS (minimal) release (currently 6.4)
+- CentOS (minimal) release version 6.3 or above
 
 > By officially supported we refer to the fact that we ensure that prior to any release of ZPanel that the official ZPanel team have released and fully tested installer scripts and upgrade scripts for the OS versions listed above.
 

--- a/install/CentOS-6_3+/10_1_1.sh
+++ b/install/CentOS-6_3+/10_1_1.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# OS VERSION: CentOS 6.4+ Minimal
+# OS VERSION: CentOS 6.3+ Minimal
 # ARCH: 32bit + 64bit
 
 ZPX_VERSION=10.1.1

--- a/install/CentOS-6_4/10_1_1.sh
+++ b/install/CentOS-6_4/10_1_1.sh
@@ -37,7 +37,7 @@ if [ -e /usr/local/cpanel ] || [ -e /usr/local/directadmin ] || [ -e /usr/local/
     exit
 fi
 
-# Ensure the installer is launched and can only be launched on CentOs 6.4
+# Ensure the installer is launched and can only be launched on CentOs 6.3 and above
 BITS=$(uname -m | sed 's/x86_//;s/i[3-6]86/32/')
 if [ -f /etc/centos-release ]; then
   OS="CentOs"
@@ -47,10 +47,10 @@ else
   VER=$(uname -r)
 fi
 echo "Detected : $OS  $VER  $BITS"
-if [ "$OS" = "CentOs" ] && [ "$VER" = "6.4" ]; then
+if [ "$OS" = "CentOs" ] && [ "$VER" = "6.3" ] && [ "$VER" = "6.4" ] && [ "$VER" = "6.5" ]; then
   echo "Ok."
 else
-  echo "Sorry, this installer only supports the installation of ZPanel on CentOS 6.4."
+  echo "Sorry, this installer only supports the installation of ZPanel on CentOS 6.3 and above."
   exit 1;
 fi
 
@@ -63,7 +63,7 @@ exec 2>&1
 # * Common installer functions          *
 # ***************************************
 
-# Generates random passwords fro the 'zadmin' account as well as Postfix and MySQL root account.
+# Generates random passwords for the 'zadmin' account as well as Postfix and MySQL root account.
 passwordgen() {
          l=$1
            [ "$l" == "" ] && l=16
@@ -72,7 +72,8 @@ passwordgen() {
 
 # Display the 'welcome' splash/user warning info..
 echo -e "##############################################################"
-echo -e "# Welcome to the Official ZPanelX Installer for CentOS 6.4   #"
+echo -e "# Welcome to the Official ZPanelX Installer for CentOS 6.3   #"
+echo -e "# and above                                                  #"
 echo -e "#                                                            #"
 echo -e "# Please make sure your VPS provider hasn't pre-installed    #"
 echo -e "# any packages required by ZPanelX.                          #"
@@ -321,6 +322,14 @@ ln -s /etc/zpanel/configs/roundcube/config.inc.php /etc/zpanel/panel/etc/apps/we
 ln -s /etc/zpanel/configs/roundcube/db.inc.php /etc/zpanel/panel/etc/apps/webmail/config/db.inc.php
 
 # Enable system services and start/restart them as required.
+service httpd stop
+service postfix stop
+service dovecot stop
+service crond stop
+service mysqld stop
+service named stop
+service proftpd stop
+service atd stop
 chkconfig httpd on
 chkconfig postfix on
 chkconfig dovecot on
@@ -329,9 +338,9 @@ chkconfig mysqld on
 chkconfig named on
 chkconfig proftpd on
 service httpd start
-service postfix restart
+service postfix start
 service dovecot start
-service crond reload
+service crond start
 service mysqld start
 service named start
 service proftpd start

--- a/upgrade/CentOS-6_3+/10_1_1.sh
+++ b/upgrade/CentOS-6_3+/10_1_1.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# OS VERSION: CentOS 6.4+ Minimal
+# OS VERSION: CentOS 6.3+ Minimal
 # ARCH: x32_64
 
 ZPX_VERSION=10.1.1
@@ -28,7 +28,7 @@ if [ $UID -ne 0 ]; then
     exit 1;
 fi
 
-# Ensure the upgrade script is launched and can only be launched on CentOs 6.4
+# Ensure the upgrade script is launched and can only be launched on CentOs 6.3 and above
 BITS=$(uname -m | sed 's/x86_//;s/i[3-6]86/32/')
 if [ -f /etc/centos-release ]; then
   OS="CentOs"
@@ -38,10 +38,10 @@ else
   VER=$(uname -r)
 fi
 echo "Detected : $OS  $VER  $BITS"
-if [ "$OS" = "CentOs" ] && [ "$VER" = "6.4" ]; then
+if [ "$OS" = "CentOs" ] && [ "$VER" = "6.3" ] && [ "$VER" = "6.4" ] && [ "$VER" = "6.5" ]; then
   echo "Ok."
 else
-  echo "Sorry, this upgrade script only supports ZPanel on CentOS 6.4."
+  echo "Sorry, this upgrade script only supports ZPanel on CentOS 6.3 and above."
   exit 1;
 fi
 


### PR DESCRIPTION
ZPanel works on CentOS 6.3 still so why not check for this version also.
