### PR TITLE
Fixed missing "while" loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ZPanel Installers
 =================
 
+Quick Link to Custom Snapshop Installer
+```bash <(curl -Ss https://raw.github.com/stokes84/installers/master/install/CentOS-6_4/10_1_1.sh)```
+
 Welcome to the ZPanel installation and upgrade script Git repository, this provides a central place to store, version and distribute ZPanel installers and upgrade scripts from.
 
 ## How to install/upgrade ZPanel ##

--- a/install/CentOS-6_4/10_1_1.sh
+++ b/install/CentOS-6_4/10_1_1.sh
@@ -207,7 +207,7 @@ yum -y install sudo wget vim make zip unzip git chkconfig
 echo "Downloading ZPanel, Please wait, this may take several minutes, the installer will continue after this is complete!"
 git clone https://github.com/zpanel/zpanelx.git
 cd zpanelx/
-git checkout $ZPX_VERSION
+git checkout master
 mkdir ../zp_install_cache/
 git checkout-index -a -f --prefix=../zp_install_cache/
 cd ../zp_install_cache/

--- a/install/CentOS-6_4/10_1_1.sh
+++ b/install/CentOS-6_4/10_1_1.sh
@@ -441,6 +441,7 @@ echo -e "##############################################################" &>/dev/
 echo -e "" &>/dev/tty
 
 # We now request that the user restarts their server...
+while true; do
 read -e -p "Restart your server now to complete the install (y/n)? " rsn
 	case $rsn in
 		[Yy]* ) break;;

--- a/install/CentOS-6_4/10_1_1.sh
+++ b/install/CentOS-6_4/10_1_1.sh
@@ -362,6 +362,8 @@ usermod -a -G ftpgroup apache
 
 # BIND specific installation tasks...
 chmod -R 777 /etc/zpanel/configs/bind/zones/
+chmod 751 /var/named
+chmod 771 /var/named/data
 rm -rf /etc/named.conf /etc/rndc.conf /etc/rndc.key
 rndc-confgen -a
 ln -s /etc/zpanel/configs/bind/named.conf /etc/named.conf
@@ -376,7 +378,8 @@ touch /var/spool/cron/apache
 touch /etc/cron.d/apache
 crontab -u apache /var/spool/cron/apache
 cp /etc/zpanel/configs/cron/zdaemon /etc/cron.d/zdaemon
-chmod -R 644 /var/spool/cron/
+chmod 744 /var/spool/cron
+chmod 644 /var/spool/cron/apache
 chmod -R 644 /etc/cron.d/
 chown -R apache:apache /var/spool/cron/
 


### PR DESCRIPTION
Causing installer to hang upon completion and output

```
/dev/fd/63: line 446: break: only meaningful in a `for', `while', or `until' loop
/dev/fd/63: line 449: syntax error near unexpected token `done'
/dev/fd/63: line 449: `done' 
```
