### PR TITLE
Missing "while" loop, cron creation, and bind logs

### DIFF
--- a/install/CentOS-6_4/10_1_1.sh
+++ b/install/CentOS-6_4/10_1_1.sh
@@ -362,6 +362,8 @@ usermod -a -G ftpgroup apache
 
 # BIND specific installation tasks...
 chmod -R 777 /etc/zpanel/configs/bind/zones/
+chmod 751 /var/named
+chmod 771 /var/named/data
 rm -rf /etc/named.conf /etc/rndc.conf /etc/rndc.key
 rndc-confgen -a
 ln -s /etc/zpanel/configs/bind/named.conf /etc/named.conf
@@ -376,7 +378,8 @@ touch /var/spool/cron/apache
 touch /etc/cron.d/apache
 crontab -u apache /var/spool/cron/apache
 cp /etc/zpanel/configs/cron/zdaemon /etc/cron.d/zdaemon
-chmod -R 644 /var/spool/cron/
+chmod 744 /var/spool/cron
+chmod 644 /var/spool/cron/apache
 chmod -R 644 /etc/cron.d/
 chown -R apache:apache /var/spool/cron/
 
@@ -441,6 +444,7 @@ echo -e "##############################################################" &>/dev/
 echo -e "" &>/dev/tty
 
 # We now request that the user restarts their server...
+while true; do
 read -e -p "Restart your server now to complete the install (y/n)? " rsn
 	case $rsn in
 		[Yy]* ) break;;


### PR DESCRIPTION
Fixing issues previously addressed @ zpanel/zpanelx@e5d0bdfbd6d9cb592f94e4e0a1133f6c10ef32bd and also tossin in the "while" loop that was missing and causing the reboot to hang and outputting..

```
/dev/fd/63: line 446: break: only meaningful in a `for', `while', or `until' loop
/dev/fd/63: line 449: syntax error near unexpected token `done'
/dev/fd/63: line 449: `done'
```
