### PR TITLE
Fixed missing db.php insert and mysql service name

### DIFF
--- a/install/Ubuntu-12_04/10_1_1.sh
+++ b/install/Ubuntu-12_04/10_1_1.sh
@@ -375,6 +375,7 @@ touch /etc/cron.d/www-data
 crontab -u www-data /var/spool/cron/crontabs/www-data
 cp /etc/zpanel/configs/cron/zdaemon /etc/cron.d/zdaemon
 chmod -R 644 /var/spool/cron/crontabs/
+chmod 744 /var/spool/cron/crontabs
 chmod -R 644 /etc/cron.d/
 chown -R www-data:www-data /var/spool/cron/crontabs/
 

--- a/install/Ubuntu-12_04/10_1_1.sh
+++ b/install/Ubuntu-12_04/10_1_1.sh
@@ -241,11 +241,12 @@ sudo chown root /etc/zpanel/panel/bin/zsudo
 chmod +s /etc/zpanel/panel/bin/zsudo
 
 # MySQL specific installation tasks...
-service mysqld start
+service mysql start
 mysqladmin -u root password "$password"
 until mysql -u root -p$password -e ";" > /dev/null 2>&1 ; do
 read -s -p "enter your root mysql password : " password
 done
+sed -i "s|YOUR_ROOT_MYSQL_PASSWORD|$password|" /etc/zpanel/panel/cnf/db.php
 mysql -u root -p$password -e "DROP DATABASE test";
 mysql -u root -p$password -e "DELETE FROM mysql.user WHERE User='root' AND Host != 'localhost'";
 mysql -u root -p$password -e "DELETE FROM mysql.user WHERE User=''";


### PR DESCRIPTION
Installer was missing 
`sed -i "s|YOUR_ROOT_MYSQL_PASSWORD|$password|" /etc/zpanel/panel/cnf/db.php`
Also mysql service was referenced as mysqld service. 
Fixes issue #13

Also fixing "Cron Task" permission issue on contabs folder. Cron Tasks can now be created.
