### PR TITLE
Added version check for CentOS v. 6.7 and v. 6.8

### DIFF
--- a/install/CentOS-6_4/10_1_1.sh
+++ b/install/CentOS-6_4/10_1_1.sh
@@ -59,7 +59,7 @@ else
 fi
 echo "Detected : $OS  $VER  $BITS"
 #warning the last version of centos and 6.x
-if [ "$OS" = "CentOs" ] && [ "$VER" = "6.0" ] || [ "$VER" = "6.1" ] || [ "$VER" = "6.2" ] || [ "$VER" = "6.3" ] || [ "$VER" = "6.4" ] || [ "$VER" = "6.5" ] ||[ "$VER" = "6.6" ]  ; then
+if [ "$OS" = "CentOs" ] && [ "$VER" = "6.0" ] || [ "$VER" = "6.1" ] || [ "$VER" = "6.2" ] || [ "$VER" = "6.3" ] || [ "$VER" = "6.4" ] || [ "$VER" = "6.5" ] || [ "$VER" = "6.6" ] || [ "$VER" = "6.7" ] || [ "$VER" = "6.8" ] ; then
   echo "Ok."
 else
   echo "Sorry, this installer only supports the installation of ZPanel on CentOS 6.x."

--- a/uninstall/centos-fedora-redhat.sh
+++ b/uninstall/centos-fedora-redhat.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# First we check if the user is 'root' before uninstalling the software
+if [ $UID -ne 0 ]; then
+    echo "Action failed! To unstall you must be logged in as 'root', please try again"
+  exit 1
+fi
+
 yum -y erase ld-linux.so.2 libbz2.so.1 libdb-4.7.so libgd.so.2 httpd php php-suhosin php-devel php-gd php-mbstring php-mcrypt php-intl php-imap php-mysql php-xml php-xmlrpc curl curl-devel perl-libwww-perl libxml2 libxml2-devel mysql-server zip webalizer gcc gcc-c++ httpd-devel at make mysql-devel bzip2-devel postfix postfix-perl-scripts bash-completion dovecot dovecot-mysql dovecot-pigeonhole mysql-server proftpd proftpd-mysql bind bind-utils bind-libs
 
 rm -rf /etc/zpanel

--- a/uninstall/ubuntu-debian.sh
+++ b/uninstall/ubuntu-debian.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# First we check if the user is 'root' before uninstalling the software
+if [ $UID -ne 0 ]; then
+    echo "Action failed! To unstall you must be logged in as 'root', please try again"
+  exit 1
+fi
+
 apt-get -y purge mysql-server mysql-server apache2 libapache2-mod-php5 libapache2-mod-bw php5-common php5-suhosin php5-cli php5-mysql php5-gd php5-mcrypt php5-curl php-pear php5-imap php5-xmlrpc php5-xsl db4.7-util zip webalizer build-essential bash-completion dovecot-mysql dovecot-imapd dovecot-pop3d dovecot-common dovecot-managesieved dovecot-lmtpd postfix postfix-mysql libsasl2-modules-sql libsasl2-modules proftpd-mod-mysql bind9 bind9utils
 apt-get -y autoremove
 rm -rf /etc/zpanel


### PR DESCRIPTION
Added version check for CentOS minimal - versions 6.7 and 6.8 on line 62.
